### PR TITLE
Timeout patch

### DIFF
--- a/Alert.php
+++ b/Alert.php
@@ -132,12 +132,13 @@ class Alert extends \yii\bootstrap\Alert
         AlertAsset::register($view);
 
         if ($this->delay > 0) {
-            $js = 'jQuery("#' . $this->options['id'] . '").fadeTo(' . $this->delay . ', 0.00, function() {
-				$(this).slideUp("slow", function() {
-					$(this).remove();
-				});
-			});';
-            $view->registerJs($js);
+            $js = 'setTimeout(function() { jQuery("#' . $this->options['id'] . '").fadeOut(2000, function() {
+                $(this).slideUp("slow", function() {
+                  $(this).remove();
+                });
+              });
+            }, '.$this->delay.');';
+        $view->registerJs($js);
         }
     }
 }

--- a/Alert.php
+++ b/Alert.php
@@ -69,10 +69,15 @@ class Alert extends \yii\bootstrap\Alert
     public $showSeparator = false;
 
     /**
-     * @var integer the delay in microseconds after which the alert will be displayed.
+     * @var integer the delay in microseconds after which the alert will be faded out.
      * Will be useful when multiple alerts are to be shown.
      */
     public $delay;
+
+    /**
+     * @var integer the time in microseconds which the alert will faded out.
+     */
+    public $fadeTime = 2000;
 
     /**
      * Runs the widget
@@ -132,7 +137,7 @@ class Alert extends \yii\bootstrap\Alert
         AlertAsset::register($view);
 
         if ($this->delay > 0) {
-            $js = 'setTimeout(function() { jQuery("#' . $this->options['id'] . '").fadeOut(2000, function() {
+            $js = 'setTimeout(function() { jQuery("#' . $this->options['id'] . '").fadeOut('.$this->fadeTime.', function() {
                 $(this).slideUp("slow", function() {
                   $(this).remove();
                 });


### PR DESCRIPTION
This fixes the alert delay issue where setting a long delay will actually fade the alert very slowly before removing it vs leaving it fully opaque for the delay duration then fading and removing it.

This can be verified on the current Alert demo page by setting the delay to 20000 or more to watch it slowly fade away.

Additionally an optional fadeTime has been added for customizing the Alert fade duration 
