### PR TITLE
Allow for kartik\widgets\Alert in flash messages

### DIFF
--- a/AlertBlock.php
+++ b/AlertBlock.php
@@ -134,7 +134,11 @@ class AlertBlock extends \yii\bootstrap\Widget
         foreach ($flashes as $alert => $message) {
             if (!empty($this->alertSettings[$alert])) {
                 $settings = $this->alertSettings[$alert];
-                $settings['body'] = $message;
+                if (is_array($message)) {
+                    $settings = array_merge($settings, $message);
+                } else {
+                    $settings['body'] = $message;
+                }
                 if (empty($settings['closeButton'])) {
                     $settings['closeButton'] = $this->closeButton;
                 }


### PR DESCRIPTION
alertSettings only applies kartik\widgets\Alert options globally. This
means that a page that could get differing success flash messages would
be restricted to the same title for those differing messages.

This minor alteration allows for a full kartik\widgets\Alert options
array to be received.

Pass the array instead of string as second parameter to setFlash
