### PR TITLE
Switched bs3 widget to bs4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "kartik-v/yii2-widget-alert",
+    "name": "factorenergia/yii2-widget-alert",
     "description": "A widget to generate alert based notifications using bootstrap-alert plugin (sub repo split from yii2-widgets)",
     "keywords": [
         "yii2",
@@ -28,7 +28,7 @@
     },
     "autoload": {
         "psr-4": {
-            "kartik\\alert\\": "src"
+            "factorenergia\\alert\\": "src"
         }
     },
     "extra": {

--- a/src/Alert.php
+++ b/src/Alert.php
@@ -7,7 +7,7 @@
  * @version 1.1.3
  */
 
-namespace kartik\alert;
+namespace factorenergia\alert;
 
 use kartik\base\Widget;
 use yii\base\InvalidConfigException;

--- a/src/AlertAsset.php
+++ b/src/AlertAsset.php
@@ -7,7 +7,7 @@
  * @version 1.1.3
  */
 
-namespace kartik\alert;
+namespace factorenergia\alert;
 
 use kartik\base\AssetBundle;
 

--- a/src/AlertBlock.php
+++ b/src/AlertBlock.php
@@ -7,7 +7,7 @@
  * @version 1.1.3
  */
 
-namespace kartik\alert;
+namespace factorenergia\alert;
 
 use Yii;
 use yii\base\InvalidConfigException;

--- a/src/AlertBlock.php
+++ b/src/AlertBlock.php
@@ -11,7 +11,7 @@ namespace kartik\alert;
 
 use Yii;
 use yii\base\InvalidConfigException;
-use yii\bootstrap\Widget;
+use yii\bootstrap4\Widget;
 use yii\helpers\Html;
 use yii\helpers\ArrayHelper;
 use kartik\base\Config;

--- a/src/AlertInterface.php
+++ b/src/AlertInterface.php
@@ -7,7 +7,7 @@
  * @version 1.1.3
  */
 
-namespace kartik\alert;
+namespace factorenergia\alert;
 
 /**
  * Interface used in [[Alert]], [[AlertBs4]] and [[AlertBs3]] widgets.

--- a/src/AlertMethodsTrait.php
+++ b/src/AlertMethodsTrait.php
@@ -7,7 +7,7 @@
  * @version 1.1.3
  */
 
-namespace kartik\alert;
+namespace factorenergia\alert;
 
 use yii\helpers\Html;
 use yii\helpers\ArrayHelper;

--- a/src/AlertTrait.php
+++ b/src/AlertTrait.php
@@ -7,7 +7,7 @@
  * @version 1.1.3
  */
 
-namespace kartik\alert;
+namespace factorenergia\alert;
 
 /**
  * Alert properties trait for [[Alert]], [[AlertBs4]] and [[AlertBs3]] widgets

--- a/src/Bs3Alert.php
+++ b/src/Bs3Alert.php
@@ -7,7 +7,7 @@
  * @version 1.1.3
  */
 
-namespace kartik\alert;
+namespace factorenergia\alert;
 
 use Yii;
 use yii\bootstrap\Alert;

--- a/src/Bs4Alert.php
+++ b/src/Bs4Alert.php
@@ -7,7 +7,7 @@
  * @version 1.1.3
  */
 
-namespace kartik\alert;
+namespace factorenergia\alert;
 
 use Yii;
 use yii\bootstrap4\Alert;


### PR DESCRIPTION
## Scope
This pull request includes a

- [X] Bug fix

## Changes
The following changes were made (this change is also documented in the [change log](https://github.com/kartik-v/yii2-widget-alert/blob/master/CHANGE.md)):

- AlertBlock class was using ``yii\bootstrap\Widget``  as dependecy instead of ``yii\bootstrap4\Widget`` 
